### PR TITLE
prune common tokens during finalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,24 @@ This is useful if you have two lists of names or titles and you want to match be
 ## Usage
 
 ```ruby
-matcher = BayesicMatching.new
-matcher.train(["it","was","the","best","of","times"], "novel")
-matcher.train(["tonight","on","the","seven","o'clock"], "news")
+trainer = BayesicMatching.new
+trainer.train(["it","was","the","best","of","times"], "novel")
+trainer.train(["tonight","on","the","seven","o'clock"], "news")
+matcher = trainer.finalize
 
 matcher.classify(["the","best","of"])
 # => {"novel"=>1.0, "news"=>0.667}
 matcher.classify(["the","time"])
 #  => {"novel"=>0.667, "news"=>0.667}
-``` 
+```
+
+## Pruning
+
+One of the fastest ways to improve the speed of matching is to prune common tokens.
+For example, if the token "the" is present in every single classification, then its presence doesn't tell you much about your confidence of a match, but we `BayesicMatching` would now return a confidence for every possible classification.
+To avoid this there is a default pruning where any token that exists in more than 50% of your classifications will get pruned during the `finalize` call.
+You can tune this pruning by passing `.finalize(pruning_percent: 0.25)`.
+In my own usage I've found that pruning tokens that exist in more than `0.2` of all classifications has almost no impact on accuracy, but gives me a significant speed boost.
 
 ## How It Works
 

--- a/examples/benchmark.rb
+++ b/examples/benchmark.rb
@@ -33,11 +33,11 @@ matching_rows = []
 end
 
 def train_matcher(training_rows)
-  matcher = BayesicMatching.new
+  trainer = BayesicMatching.new
   training_rows.each do |row|
-    matcher.train(row[:tokens], row[:id])
+    trainer.train(row[:tokens], row[:id])
   end
-  matcher
+  trainer.finalize(pruning_percent: 0.2)
 end
 
 def attempt_matches(matcher, matching_rows, print_mismatch_data = false)

--- a/lib/bayesic_matching/matcher.rb
+++ b/lib/bayesic_matching/matcher.rb
@@ -1,0 +1,22 @@
+class BayesicMatching
+  class Matcher
+    def initialize(class_count:, by_token:)
+      @class_count = class_count
+      @by_token = by_token
+      @prior = 1.0 / class_count
+    end
+
+    def classify(tokens)
+      tokens = tokens.reject{|t| !@by_token.has_key?(t) }.uniq
+      tokens.each_with_object({}) do |token, hash|
+        @by_token[token][:classifications].each do |c|
+          p_klass = hash[c] || @prior
+          p_not_klass = 1.0 - p_klass
+          p_token_given_klass = 1.0
+          p_token_given_not_klass = (@by_token[token][:count] - 1) / @class_count.to_f
+          hash[c] = (p_token_given_klass * p_klass) / ((p_token_given_klass * p_klass) + (p_token_given_not_klass * p_not_klass))
+        end
+      end
+    end
+  end
+end

--- a/spec/bayesic_matching_spec.rb
+++ b/spec/bayesic_matching_spec.rb
@@ -6,18 +6,21 @@ RSpec.describe BayesicMatching do
   end
 
   it "can classify matching tokens" do
-    classification = subject.classify(["once","upon","a","time"])
+    matcher = subject.finalize
+    classification = matcher.classify(["once","upon","a","time"])
     expect(classification.keys).to include("story")
     expect(classification["story"]).to be >= 0.9
   end
 
   it "can classify not exact matches" do
-    classification = subject.classify(["the","time"])
+    matcher = subject.finalize
+    classification = matcher.classify(["the","time"])
     expect(classification.keys).to include("story")
     expect(classification["story"]).to be >= 0.9
   end
 
   it "returns no potential matches for nonsense" do
-    expect(subject.classify(["ferby"])).to eq({})
+    matcher = subject.finalize
+    expect(matcher.classify(["ferby"])).to eq({})
   end
 end


### PR DESCRIPTION
Based on what I learned in https://github.com/mmmries/bayesic/issues/1 I tested the same type of optimization here. It appears that ruby was caching the size of a `Set` because doing the counts during finalization only bumped the performance a small amount (~17% faster). The pruning made a big difference and in my sample set of 10k company names I was able to move matching from `1,220/sec` to `29,625/sec` with `pruning_percent: 0.2`. This pruning only changed the accuracy for my example set by 0.5%.